### PR TITLE
Staging

### DIFF
--- a/css/new-age.css
+++ b/css/new-age.css
@@ -351,29 +351,20 @@ section.sponsors h2 {
   margin-top: -25px;
   font-size: 50px;
 }
-section.sponsors .badges .badge-link {
-  display: block;
-  margin-bottom: 100px;
+section.sponsors .badges center {
+  width: 100%;
 }
 section.sponsors .badges img {
-  height: 175px;
   border-radius: 50%;
-}
-section.sponsors .badges .badge-link:last-child {
-  margin-bottom: 0;
-}
-@media (min-width: 768px) {
-  section.sponsors .badges .badge-link {
-    display: block;
-    margin-bottom: 10px;
-  }
+  width: inherit;
+  height: auto;
+  margin-bottom: 20px;
 }
 @media (min-width: 768px) {
   section.sponsors h2 {
     font-size: 70px;
   }
 }
-
 #bigdatafed {
     background: white;
 }

--- a/index.html
+++ b/index.html
@@ -271,19 +271,19 @@
                     <br>
                     <div class="badges">
                         <div class="row">
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/acm.png" alt=""></center>
                             </div>
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/acm-w.png" alt=""></center>
                             </div>
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/scu_engineering.png" alt=""></center>
                             </div>
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/frugal.png" alt=""></center>
                             </div>
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/bigdatafedtext.png" alt=""></center>
                             </div>
                         </div>
@@ -302,28 +302,28 @@
                     <div class="badges">
                     <br>
                         <div class="row">
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/acm.png" alt=""></center>
                             </div>
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/acm-w.png" alt=""></center>
                             </div>
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/scu_engineering.png" alt=""></center>
                             </div>
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/frugal.png" alt=""></center>
                             </div>
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/sanJose.png" alt=""></center>
                             </div>
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/redBull.jpg" alt=""></center>
                             </div>
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/IEEESight.jpg" alt=""></center>
                             </div>
-                            <div class="col-md-3 col-sm-4 col-xs-6">
+                            <div class="col-md-3 col-xs-4">
                                 <center><img class="badge-link" src="img/markkula.jpg" alt=""></center>
                             </div>
                         </div>

--- a/index.html
+++ b/index.html
@@ -271,19 +271,19 @@
                     <br>
                     <div class="badges">
                         <div class="row">
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/acm.png" alt=""></center>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/acm-w.png" alt=""></center>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/scu_engineering.png" alt=""></center>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/frugal.png" alt=""></center>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/bigdatafedtext.png" alt=""></center>
                             </div>
                         </div>
@@ -302,31 +302,28 @@
                     <div class="badges">
                     <br>
                         <div class="row">
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/acm.png" alt=""></center>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/acm-w.png" alt=""></center>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/scu_engineering.png" alt=""></center>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/frugal.png" alt=""></center>
                             </div>
-                        </div>
-                        <br>
-                        <div class="row">
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/sanJose.png" alt=""></center>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/redBull.jpg" alt=""></center>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/IEEESight.jpg" alt=""></center>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-3 col-sm-4 col-xs-6">
                                 <center><img class="badge-link" src="img/markkula.jpg" alt=""></center>
                             </div>
                         </div>


### PR DESCRIPTION
Before, badges were not leveraging Bootstrap and instead manually adjusting sizing for mobile. The changes create proper sizing and spacing with 4 badge columns for medium screens and larger while having 3 badge columns for smaller screen sizes.